### PR TITLE
Remove unused hashlib import

### DIFF
--- a/rom_cleanup.py
+++ b/rom_cleanup.py
@@ -19,7 +19,6 @@ import argparse
 import shutil
 import json
 import time
-import hashlib
 from pathlib import Path
 from collections import defaultdict
 from difflib import SequenceMatcher


### PR DESCRIPTION
## Summary
- drop unused hashlib import from rom_cleanup script

## Testing
- `python -m py_compile rom_cleanup.py`
- `python rom_cleanup.py --help`


------
https://chatgpt.com/codex/tasks/task_e_688ec0c945fc8328b48ebc585660e916