### PR TITLE
Normalize custom extensions

### DIFF
--- a/rom_cleanup.py
+++ b/rom_cleanup.py
@@ -388,7 +388,11 @@ def main():
     
 
     if args.extensions:
-        custom_extensions = {ext.strip().lower() for ext in args.extensions.split(',')}
+        custom_extensions = set()
+        for ext in args.extensions.split(','):
+            ext = ext.strip().lower()
+            ext = ext if ext.startswith('.') else '.' + ext
+            custom_extensions.add(ext)
         ROM_EXTENSIONS.update(custom_extensions)
     
     print(f"Scanning ROM files in: {os.path.abspath(args.directory)}")


### PR DESCRIPTION
## Summary
- Normalize custom extensions so user-provided values are prefixed with a dot.

## Testing
- `python -m py_compile rom_cleanup.py`
- `python rom_cleanup.py --help`


------
https://chatgpt.com/codex/tasks/task_e_688ec0c7fab88328bd077337ce8b610f