### PR TITLE
Use IGDB where clause for platform filtering

### DIFF
--- a/rom_cleanup.py
+++ b/rom_cleanup.py
@@ -120,13 +120,13 @@ def query_igdb_game(game_name, file_extension=None):
         target_platforms = []
         if file_extension and file_extension.lower() in PLATFORM_MAPPING:
             target_platforms = PLATFORM_MAPPING[file_extension.lower()]
-            platform_filter = f"& platforms = ({','.join(map(str, target_platforms))})"
-        
+            platform_filter = f"where platforms = ({','.join(map(str, target_platforms))});"
+
         query = f'''
         search "{game_name}";
         fields name, alternative_names.name, platforms;
-        limit 15;
         {platform_filter}
+        limit 15;
         '''
         
         headers = {


### PR DESCRIPTION
## Summary
- replace improper `& platforms` filter with a valid `where platforms = (...)` clause when querying IGDB
- move platform filter before the limit and include trailing semicolon for valid IGDB syntax

## Testing
- `python -m py_compile rom_cleanup.py`
- `python rom_cleanup.py --help`


------
https://chatgpt.com/codex/tasks/task_e_688ec084ab1c8328845bffc32fb582ea