### PR TITLE
Handle missing requests dependency gracefully

### DIFF
--- a/rom_cleanup_gui.py
+++ b/rom_cleanup_gui.py
@@ -19,7 +19,11 @@ from datetime import datetime
 import json
 import time
 import hashlib
-import requests
+try:
+    import requests
+except ImportError:
+    requests = None
+    print("The 'requests' library is required for IGDB features. Please install it to enable them.")
 from difflib import SequenceMatcher
 
 # IGDB API configuration (set as environment variables)


### PR DESCRIPTION
## Summary
- Wrap `requests` import in a `try`/`except` block so the GUI runs even if the library isn't installed.

## Testing
- `python -m py_compile rom_cleanup_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_688ec0c9fd688328b6cd9f6221029150