### PR TITLE
Check for PyInstaller before building executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ python rom_cleanup_gui.py
 
 The GUI provides directory selection and toggle options for the same features as the CLI.
 
+### Building an Executable
+
+To create a standalone executable of the GUI, the project provides `build_exe.py`. The script uses [PyInstaller](https://www.pyinstaller.org/), which must be installed manually:
+
+```bash
+pip install pyinstaller
+python build_exe.py
+```
+
+The resulting executable will be placed in the `dist/` directory.
+
 ### IGDB API Setup (Optional)
 
 Providing IGDB credentials improves matching, particularly for games with alternate titles.

--- a/build_exe.py
+++ b/build_exe.py
@@ -5,24 +5,20 @@ Build script to create ROM Cleanup GUI executable
 
 import subprocess
 import sys
-import os
 from pathlib import Path
 
-def install_pyinstaller():
-    """Install PyInstaller if not already installed"""
+
+def check_pyinstaller() -> bool:
+    """Check that PyInstaller is available."""
     try:
-        import PyInstaller
-        print("✓ PyInstaller already installed")
+        import PyInstaller  # noqa: F401  (imported for availability check)
+        print("✓ PyInstaller found")
         return True
     except ImportError:
-        print("Installing PyInstaller...")
-        try:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "pyinstaller"])
-            print("✓ PyInstaller installed successfully")
-            return True
-        except subprocess.CalledProcessError:
-            print("✗ Failed to install PyInstaller")
-            return False
+        print(
+            "✗ PyInstaller is not installed. Please run 'pip install pyinstaller' and rerun this script."
+        )
+        return False
 
 def create_executable():
     """Create the executable using PyInstaller"""
@@ -77,8 +73,8 @@ def main():
         print("✗ rom_cleanup_gui.py not found in current directory")
         return
         
-    # Install PyInstaller if needed
-    if not install_pyinstaller():
+    # Ensure PyInstaller is installed
+    if not check_pyinstaller():
         return
         
     # Create executable


### PR DESCRIPTION
## Summary
- Fail fast if PyInstaller is missing instead of attempting an automatic install.
- Document building the executable and the need to install PyInstaller manually.

## Testing
- `python -m py_compile build_exe.py`
- `python - <<'PY'
import build_exe
build_exe.check_pyinstaller()
PY`


------
https://chatgpt.com/codex/tasks/task_e_688ec8e2fa9c8328bff9b02fc3dc11bb