### PR TITLE
Separate build and runtime dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ A Python utility to streamline large ROM collections by removing redundant regio
 
 ## Installation
 1. Ensure Python 3.9+ is installed.
-2. Install dependencies:
+2. Install runtime dependencies:
 
 ```bash
 pip install -r requirements.txt
+```
+
+3. (Optional) Install build dependencies if you plan to create a standalone executable:
+
+```bash
+pip install -r requirements-build.txt
 ```
 
 ## Usage
@@ -36,6 +42,14 @@ python rom_cleanup_gui.py
 ```
 
 The GUI provides directory selection and toggle options for the same features as the CLI.
+
+### Building an executable
+
+After installing the build requirements, create a standalone executable with:
+
+```bash
+python build_exe.py
+```
 
 ### IGDB API Setup (Optional)
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,2 @@
+# Build requirements for ROM Cleanup GUI
+pyinstaller>=5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # Requirements for ROM Cleanup GUI
-# Core dependencies
-pyinstaller>=5.0
+# Runtime dependencies
 requests>=2.25.0


### PR DESCRIPTION
## Summary
- Split PyInstaller into new `requirements-build.txt` for build-time tooling.
- Keep `requests` as the only runtime dependency in `requirements.txt`.
- Document separate runtime and build dependency steps plus executable build instructions.

## Testing
- `python -m py_compile build_exe.py rom_cleanup.py rom_cleanup_gui.py`
- `pip install -r requirements.txt`
- `pip install -r requirements-build.txt`


------
https://chatgpt.com/codex/tasks/task_e_688ec8e2861c8328aa09b6b307fcf412