### PR TITLE
refactor: replace IGDB credentials with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,14 @@ python build_exe.py
 The resulting executable will be placed in the `dist/` directory.
 
 ### IGDB API Setup (Optional)
+
+Some features, such as alternative name lookup, rely on the IGDB API. To
+enable them, create an API application at [IGDB](https://api-docs.igdb.com/)
+and export your credentials before running the tool:
+
+```bash
+export IGDB_CLIENT_ID="your-client-id"
+export IGDB_ACCESS_TOKEN="your-access-token"
+```
+
+If these variables are not set, the program will skip IGDB lookups.

--- a/rom_cleanup_gui.py
+++ b/rom_cleanup_gui.py
@@ -27,8 +27,8 @@ except ImportError:
 from difflib import SequenceMatcher
 
 # IGDB API configuration
-IGDB_CLIENT_ID = '9dwep24aejb1hqjuwotlm2xsqmpc40'
-IGDB_ACCESS_TOKEN = '5xjjug6z09wh8mogidhzurv65fwjgu'
+IGDB_CLIENT_ID = os.getenv('IGDB_CLIENT_ID', '')
+IGDB_ACCESS_TOKEN = os.getenv('IGDB_ACCESS_TOKEN', '')
 
 # IGDB configuration
 GAME_CACHE = {}


### PR DESCRIPTION
## Summary
- remove hard-coded IGDB API credentials from the GUI
- document how to configure IGDB via environment variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ed44520488328b34c7a9782a3800c