### PR TITLE
Add missing MIT license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ROM Collection Cleanup Tool contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/test_rom_utils.py
+++ b/test_rom_utils.py
@@ -1,0 +1,12 @@
+import pytest
+from rom_utils import get_region, get_base_name
+
+
+def test_get_region_returns_expected_region():
+    """get_region returns region string based on filename."""
+    assert get_region("Super Mario Bros (USA).nes") == "usa"
+
+
+def test_get_base_name_strips_metadata():
+    """get_base_name removes region and revision info from filename."""
+    assert get_base_name("Super Mario Bros (USA) (Rev 1).nes") == "Super Mario Bros"


### PR DESCRIPTION
## Summary
- add MIT `LICENSE` file referenced in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890914378588328b8abe7979245c52a