### PR TITLE
Fix deprecated GitHub Actions upload-artifact action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         pyinstaller --onefile --windowed --name="ROM-Cleanup-Tool" rom_cleanup_gui.py
 
     - name: Upload executable
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: rom-cleanup-tool-windows
         path: dist/ROM-Cleanup-Tool.exe


### PR DESCRIPTION
- Update actions/upload-artifact from v3 to v4 to resolve deprecation warning
- This fixes the CI build failure caused by deprecated action version
- Maintains same functionality with latest supported version