### PR TITLE
Align lint settings and fix flake8 warnings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ organization of settings and parameters.
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Set
+from typing import Set
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ Issues = "https://github.com/yourusername/rom-cleanup-tool/issues"
 where = ["."]
 include = ["rom_cleanup*", "rom_utils*", "config*"]
 
+[tool.flake8]
+max-line-length = 88
+
 [tool.black]
 line-length = 88
 target-version = ['py39']

--- a/rom_cleanup.py
+++ b/rom_cleanup.py
@@ -638,10 +638,7 @@ def main() -> int:
 
     # Check IGDB API availability
     if not IGDB_CLIENT_ID or not IGDB_ACCESS_TOKEN:
-        print(
-            "⚠️  IGDB API credentials not configured - "
-            "using basic name matching only"
-        )
+        print("⚠️  IGDB credentials missing - basic name matching only")
         print(
             "   For better matching of regional variants, set "
             "IGDB_CLIENT_ID and IGDB_ACCESS_TOKEN"

--- a/rom_cleanup.py
+++ b/rom_cleanup.py
@@ -16,7 +16,6 @@ import argparse
 import json
 import logging
 import os
-import re
 import shutil
 import sys
 import time
@@ -390,7 +389,8 @@ def scan_roms(
         rom_extensions: Set of file extensions to consider as ROM files
 
     Returns:
-        Dictionary mapping canonical names to lists of (file_path, region, original_name) tuples
+        Dictionary mapping canonical names to lists of
+        (file_path, region, original_name) tuples
     """
     rom_groups = defaultdict(list)
 
@@ -421,7 +421,7 @@ def scan_roms(
     save_game_cache()
 
     # Debug output: show game groupings
-    print(f"\nGame groupings after processing:")
+    print("\nGame groupings after processing:")
     for canonical_name, roms in rom_groups.items():
         if len(roms) > 1:
             print(f"  🎮 {canonical_name}:")
@@ -456,9 +456,11 @@ def find_duplicates_to_remove(
             regions[region].append((file_path, original_name))
             original_names.add(original_name)
 
-        # If we have both Japanese and USA versions, verify they are actually the same game
+        # If we have both Japanese and USA versions,
+        # verify they are actually the same game
         if "japan" in regions and "usa" in regions:
-            # Trust the canonical name from API - if they have the same canonical name, they're the same game
+            # Trust the canonical name from API - if they have the same
+            # canonical name, they're the same game
             # Only do string similarity check as a fallback for non-API matches
             max_ratio = 0.0
             for _, j_name in regions["japan"]:
@@ -573,8 +575,8 @@ def move_to_safe_folder(rom_directory: str, to_remove: List[Path]) -> int:
             print(f"  Permission denied moving {file_path}: {e}")
             logger.error(f"Permission denied moving {file_path}: {e}")
         except FileNotFoundError as e:
-            print(f"  File not found: {file_path}")
-            logger.error(f"File not found during move: {file_path}")
+            print(f"  File not found: {file_path}: {e}")
+            logger.error(f"File not found during move: {file_path}: {e}")
         except OSError as e:
             print(f"  OS error moving {file_path}: {e}")
             logger.error(f"OS error moving {file_path}: {e}")
@@ -636,9 +638,13 @@ def main() -> int:
 
     # Check IGDB API availability
     if not IGDB_CLIENT_ID or not IGDB_ACCESS_TOKEN:
-        print("⚠️  IGDB API credentials not configured - using basic name matching only")
         print(
-            "   For better matching of regional variants, set IGDB_CLIENT_ID and IGDB_ACCESS_TOKEN"
+            "⚠️  IGDB API credentials not configured - "
+            "using basic name matching only"
+        )
+        print(
+            "   For better matching of regional variants, set "
+            "IGDB_CLIENT_ID and IGDB_ACCESS_TOKEN"
         )
         print("   See README_API_CREDENTIALS.md for setup instructions")
     elif requests:
@@ -683,7 +689,8 @@ def main() -> int:
         moved_count = move_to_safe_folder(args.directory, to_remove)
         print(f"\nSuccessfully moved {moved_count} files to 'to_delete' folder.")
         print(
-            f"Review the files in '{args.directory}/to_delete' and delete the folder when ready."
+            f"Review the files in '{args.directory}/to_delete' "
+            "and delete the folder when ready."
         )
     else:
         print("\nRemoving files...")

--- a/rom_cleanup_gui.py
+++ b/rom_cleanup_gui.py
@@ -2,13 +2,13 @@
 """
 ROM Collection Cleanup Tool - GUI Version
 
-A streamlined, user-friendly GUI tool for managing ROM collections by removing duplicates
-based on region preferences while preserving unique releases.
+A streamlined, user-friendly GUI tool for managing ROM collections
+by removing duplicates based on region preferences while preserving
+unique releases.
 """
 
 import hashlib
 import json
-import os
 import shutil
 import sys
 import threading
@@ -26,7 +26,8 @@ try:
 except ImportError:
     requests = None
     print(
-        "The 'requests' library is required for IGDB features. Please install it to enable them."
+        "The 'requests' library is required for IGDB features. "
+        "Please install it to enable them."
     )
 from difflib import SequenceMatcher
 
@@ -714,12 +715,14 @@ class ROMCleanupGUI:
         if not client_id:
             return (
                 False,
-                "IGDB Client ID not configured - enter your credentials in IGDB API tab",
+                "IGDB Client ID not configured - "
+                "enter your credentials in IGDB API tab",
             )
         elif not access_token:
             return (
                 False,
-                "IGDB Access Token not configured - enter your credentials in IGDB API tab",
+                "IGDB Access Token not configured - "
+                "enter your credentials in IGDB API tab",
             )
         elif not requests:
             return False, "requests library not available"
@@ -748,12 +751,14 @@ class ROMCleanupGUI:
                     else:
                         return (
                             False,
-                            "Authentication failed (401) - check Client ID and Access Token",
+                            "Authentication failed (401) - check Client ID "
+                            "and Access Token",
                         )
-                except:
+                except Exception:
                     return (
                         False,
-                        "Authentication failed (401) - check Client ID and Access Token",
+                        "Authentication failed (401) - check Client ID "
+                        "and Access Token",
                     )
             elif response.status_code == 429:
                 return False, "Rate limit exceeded (429) - wait a few minutes"
@@ -887,10 +892,10 @@ class ROMCleanupGUI:
                 self.log_message(f"Response text: {response.text[:200]}...")
 
         except requests.exceptions.ConnectionError as e:
-            self.log_message("❌ Connection error")
+            self.log_message(f"❌ Connection error: {e}")
             self.log_message("Check your internet connection")
         except requests.exceptions.Timeout as e:
-            self.log_message("❌ Request timeout")
+            self.log_message(f"❌ Request timeout: {e}")
             self.log_message("The API request took too long")
         except Exception as e:
             self.log_message(f"❌ Unexpected error: {e}")
@@ -1205,11 +1210,20 @@ class ROMCleanupGUI:
 
         # Confirm before executing with operation-specific message
         if operation == "move":
-            message = f"Move {len(to_remove)} duplicate files to 'to_delete' folder?\n\nThis is a safe operation - files will not be permanently deleted."
+            message = (
+                f"Move {len(to_remove)} duplicate files to 'to_delete' folder?\n\n"
+                "This is a safe operation - files will not be permanently deleted."
+            )
         elif operation == "backup":
-            message = f"Backup and then delete {len(to_remove)} duplicate files?\n\nFiles will be copied to backup folder first, then deleted."
+            message = (
+                f"Backup and then delete {len(to_remove)} duplicate files?\n\n"
+                "Files will be copied to backup folder first, then deleted."
+            )
         else:  # delete
-            message = f"PERMANENTLY DELETE {len(to_remove)} duplicate files?\n\n⚠️ WARNING: This cannot be undone!"
+            message = (
+                f"PERMANENTLY DELETE {len(to_remove)} duplicate files?\n\n"
+                "⚠️ WARNING: This cannot be undone!"
+            )
 
         response = messagebox.askyesno("Confirm Operation", message)
 
@@ -1526,7 +1540,9 @@ def query_igdb_game(game_name, file_extension=None, client_id=None, access_token
                     "matched_on": best_match["match_name"],
                 }
                 print(
-                    f"Best match for '{game_name}': '{best_match['match_name']}' (score: {best_match['score']:.2f})"
+                    f"Best match for '{game_name}': "
+                    f"'{best_match['match_name']}' "
+                    f"(score: {best_match['score']:.2f})"
                 )
                 GAME_CACHE[cache_key] = result
                 time.sleep(0.25)  # Rate limiting

--- a/tests/test_rom_utils.py
+++ b/tests/test_rom_utils.py
@@ -1,7 +1,5 @@
 """Tests for ROM utilities module."""
 
-import pytest
-
 from rom_utils import get_base_name, get_region
 
 


### PR DESCRIPTION
## Summary
- add flake8 configuration to enforce 88 character line length
- remove unused imports and tidy error messages across modules
- split long strings and strengthen exception handling in the GUI script

## Testing
- `flake8 && echo flake8-ok`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890b2d7f2188328ab04f08dd2942177