### PR TITLE
Skip to_delete directories during ROM scan

### DIFF
--- a/rom_cleanup.py
+++ b/rom_cleanup.py
@@ -403,6 +403,8 @@ def scan_roms(
     print("Processing ROM files...")
 
     for file_path in directory.rglob("*"):
+        if "to_delete" in file_path.parts:
+            continue
         if file_path.is_file() and file_path.suffix.lower() in rom_extensions:
             filename = file_path.name
             base_name = get_base_name(filename)

--- a/tests/test_scan_roms.py
+++ b/tests/test_scan_roms.py
@@ -1,0 +1,19 @@
+import rom_cleanup
+
+
+def test_scan_roms_ignores_to_delete(tmp_path, monkeypatch):
+    monkeypatch.setattr(rom_cleanup, "CACHE_FILE", tmp_path / "cache.json")
+
+    rom_file = tmp_path / "game.nes"
+    rom_file.write_text("data")
+
+    to_delete_dir = tmp_path / "to_delete"
+    to_delete_dir.mkdir()
+    (to_delete_dir / "bad.nes").write_text("data")
+
+    rom_groups = rom_cleanup.scan_roms(str(tmp_path), {".nes"})
+
+    rom_paths = [fp for group in rom_groups.values() for fp, _, _ in group]
+    assert rom_file in rom_paths
+    assert all("to_delete" not in fp.parts for fp in rom_paths)
+    assert len(rom_paths) == 1


### PR DESCRIPTION
## Summary
- avoid scanning ROMs in `to_delete` folders
- add regression test verifying `scan_roms` ignores `to_delete`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890c69fee5083289d4a7b6fa512613c