### PR TITLE
Fix: Preserve numbered sequels in API canonical name lookup

### DIFF
--- a/rom_cleanup.py
+++ b/rom_cleanup.py
@@ -575,6 +575,16 @@ def get_canonical_name(game_name: str, file_extension: Optional[str] = None) -> 
         cached_name = cached_key.split("_")[0]  # Remove file extension part
         ratio = SequenceMatcher(None, game_name_clean, cached_name).ratio()
 
+        # Check if this would be incorrectly matching numbered sequels
+        import re
+
+        game_numbers = re.findall(r"\b\d+\b", game_name)
+        cached_numbers = re.findall(r"\b\d+\b", cached_canonical)
+
+        # Don't match if they have different numbers (prevents sequel confusion)
+        if game_numbers != cached_numbers and (game_numbers or cached_numbers):
+            continue
+
         # More lenient threshold for cross-language matching
         if ratio > best_ratio and ratio > 0.75:  # Lowered from 0.85
             best_ratio = ratio

--- a/rom_cleanup_gui.py
+++ b/rom_cleanup_gui.py
@@ -111,6 +111,11 @@ def get_unified_canonical_name(
         if original_numbers and not api_numbers:
             return original_name
 
+        # If original has NO numbers but API result DOES have numbers, preserve the original
+        # (API likely returned wrong sequel for the base game)
+        if not original_numbers and api_numbers:
+            return original_name
+
         # If both have numbers but they're different, preserve the original
         if original_numbers and api_numbers and original_numbers != api_numbers:
             return original_name

--- a/rom_cleanup_gui.py
+++ b/rom_cleanup_gui.py
@@ -1419,6 +1419,15 @@ class ROMCleanupGUI:
                     igdb_access_token,
                     logger=self.log_message,
                 )
+
+                # Debug logging for canonical name assignment
+                if base_name != canonical_name:
+                    self.log_message(
+                        f"   Canonical name: '{base_name}' -> '{canonical_name}'"
+                    )
+                else:
+                    self.log_message(f"   Canonical name: '{canonical_name}'")
+
                 rom_groups[canonical_name].append((file_path, region, base_name))
 
                 # Update progress

--- a/rom_cleanup_gui.py
+++ b/rom_cleanup_gui.py
@@ -98,9 +98,28 @@ def get_unified_canonical_name(
     igdb_access_token=None,
     logger=None,
 ):
-    """Get canonical name using the selected API."""
+    """Get canonical name using the selected API with sequel preservation."""
+    import re
+
+    def preserve_sequel_numbers(original_name, api_name):
+        """Preserve numbered sequels when API returns generic name."""
+        # Extract numbers from the original name
+        original_numbers = re.findall(r"\b\d+\b", original_name)
+        api_numbers = re.findall(r"\b\d+\b", api_name)
+
+        # If original has numbers but API result doesn't, preserve the original
+        if original_numbers and not api_numbers:
+            return original_name
+
+        # If both have numbers but they're different, preserve the original
+        if original_numbers and api_numbers and original_numbers != api_numbers:
+            return original_name
+
+        return api_name
+
     if api_choice == "thegamesdb":
-        return get_canonical_name(game_name, file_extension, tgdb_api_key, logger)
+        api_result = get_canonical_name(game_name, file_extension, tgdb_api_key, logger)
+        return preserve_sequel_numbers(game_name, api_result)
     elif api_choice == "igdb":
         # Use the original IGDB logic from rom_cleanup.py
         if query_igdb_game and igdb_client_id and igdb_access_token:
@@ -111,7 +130,8 @@ def get_unified_canonical_name(
             rom_cleanup.IGDB_ACCESS_TOKEN = igdb_access_token
             result = query_igdb_game(game_name, file_extension)
             if result:
-                return result.get("canonical_name", game_name)
+                api_result = result.get("canonical_name", game_name)
+                return preserve_sequel_numbers(game_name, api_result)
 
     # Fallback to original name
     return game_name


### PR DESCRIPTION
- Prevents Tony Hawk Pro Skater 2/3 from being grouped together as duplicates
- API calls were returning generic names without sequel numbers
- Added preserve_sequel_numbers() function to detect and preserve numeric sequels
- Fixes issue where different games in a series were incorrectly treated as duplicates
- Maintains API benefits while preserving important game distinctions