### PR TITLE
Include source paths in ROM batch scan groups

### DIFF
--- a/batch_processor.py
+++ b/batch_processor.py
@@ -294,11 +294,12 @@ class ROMBatchScanner:
 
         def process_rom_file(
             file_path: Path,
-        ) -> Tuple[bool, Optional[Tuple[str, str, str]]]:
+        ) -> Tuple[bool, Optional[Tuple[str, str, str, Path]]]:
             """Process a single ROM file.
 
             Returns:
-                (success, (canonical_name, region, original_name)) or (False, error_message)
+                (success, (canonical_name, region, original_name, file_path))
+                or (False, error_message)
             """
             try:
                 filename = file_path.name
@@ -318,7 +319,7 @@ class ROMBatchScanner:
                 if not base_name:
                     return False, f"Could not parse game name from {filename}"
 
-                return True, (base_name, region, filename)
+                return True, (base_name, region, filename, file_path)
 
             except Exception as e:
                 return False, str(e)
@@ -333,9 +334,8 @@ class ROMBatchScanner:
 
         # Group results by canonical name
         for result in batch_results["results"]:
-            canonical_name, region, original_name = result
-            # TODO: Track and expose the source file path for each result when
-            # batch processing is enhanced to provide that information.
+            canonical_name, region, original_name, file_path = result
+            rom_groups[canonical_name].append((file_path, region, original_name))
 
         logger.info(f"ROM batch scan completed: {len(rom_groups)} unique games found")
 


### PR DESCRIPTION
## Summary
- Track the original file path when scanning ROMs in batches
- Group batch scan results by canonical name with `(file_path, region, original_name)` tuples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895e7c43b2c8328bf99d8502d43c80a