### PR TITLE
Use dynamic config directory for credentials

### DIFF
--- a/credential_manager.py
+++ b/credential_manager.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 # Service name for credentials
 SERVICE_NAME = "rom-cleanup-tool"
-CONFIG_DIR = Path.home() / ".rom-cleanup-tool"
 
 
 def _get_config_dir() -> Path:
@@ -27,7 +26,7 @@ def _get_config_dir() -> Path:
 
         temp_dir = tempfile.mkdtemp(prefix="rom-cleanup-test-")
         return Path(temp_dir) / ".rom-cleanup-tool"
-    return CONFIG_DIR
+    return Path.home() / ".rom-cleanup-tool"
 
 
 class CredentialManager:
@@ -35,8 +34,8 @@ class CredentialManager:
 
     def __init__(self) -> None:
         """Initialize the credential manager."""
-        # Resolve paths at runtime so tests can patch CONFIG_DIR
-        self.config_dir = CONFIG_DIR
+        # Resolve paths at runtime so tests can patch directory logic
+        self.config_dir = _get_config_dir()
         self.credentials_file = self.config_dir / "credentials.json"
 
         # Create config directory if it doesn't exist


### PR DESCRIPTION
## Summary
- resolve credential directory at runtime
- remove global CONFIG_DIR and update tests
- ensure CI environments use temporary paths

## Testing
- `pytest`
- `flake8`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_6895e7bbdca883288cef543c502446bd