### PR TITLE
Remove unused request counter

### DIFF
--- a/tests/test_tgdb_rate_limit.py
+++ b/tests/test_tgdb_rate_limit.py
@@ -1,0 +1,28 @@
+import tgdb_query
+
+def test_enforce_rate_limit_monotonic(monkeypatch):
+    times = [1000, 1000, 1000.5, 1001.5]
+
+    def fake_time():
+        return times.pop(0)
+
+    sleep_calls = []
+
+    def fake_sleep(duration):
+        sleep_calls.append(duration)
+
+    monkeypatch.setattr(tgdb_query.time, "time", fake_time)
+    monkeypatch.setattr(tgdb_query.time, "sleep", fake_sleep)
+
+    tgdb_query._last_request_time = 0
+    tgdb_query._hour_start = 0
+    tgdb_query._requests_this_hour = 0
+    tgdb_query.MIN_REQUEST_INTERVAL = 1
+    tgdb_query.MAX_REQUESTS_PER_HOUR = 500
+
+    tgdb_query._enforce_rate_limit()
+    assert tgdb_query._requests_this_hour == 1
+
+    tgdb_query._enforce_rate_limit()
+    assert sleep_calls == [0.5]
+    assert tgdb_query._requests_this_hour == 2

--- a/tests/test_tgdb_rate_limit.py
+++ b/tests/test_tgdb_rate_limit.py
@@ -1,5 +1,6 @@
 import tgdb_query
 
+
 def test_enforce_rate_limit_monotonic(monkeypatch):
     times = [1000, 1000, 1000.5, 1001.5]
 

--- a/tgdb_query.py
+++ b/tgdb_query.py
@@ -17,7 +17,6 @@ GAME_CACHE = {}
 
 # Rate limiting globals
 _last_request_time = 0
-_request_count = 0
 _hour_start = 0
 _requests_this_hour = 0
 


### PR DESCRIPTION
## Summary
- delete unused `_request_count` variable from TGDB query module
- add regression test to verify rate limiting increments counter and enforces pause

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895e7b960e88328b1295cdf83f27866